### PR TITLE
Abpath

### DIFF
--- a/kappa/__init__.py
+++ b/kappa/__init__.py
@@ -13,6 +13,10 @@ Created on Mon Mar 21 13:09:01 2016
 #             
 #for module, names in available:
 #    exec('from .%s import %s' % (module, ', '.join(names)))
+import os
+
+#russ on stackoverflow
+package_dir = os.path.dirname(__file__)
 
 from .molecule import *
 from .forcefield import *

--- a/kappa/antechamber/atomtype.py
+++ b/kappa/antechamber/atomtype.py
@@ -7,18 +7,17 @@ Created on Fri Apr 29 13:38:20 2016
 
 import csv
 import re
+from .. import package_dir
 
 nums = ["1", "2", "3", "4"]
 atomicSymDict = {"H":[1], "C":[6], "N":[7], "O":[8], "F":[9], "P":[15], "S":[16], "Cl":[17], 
                  "Br":[35], "I":[53], "XX":[6,7,8,15,16], "XA":[8,16], "XB":[7,15], "XD":[15,16]}
 
-amberFile = "AMBER_kerr_edit.txt"
-
 def main(molecule):
     
-    file_ = amberFile
+    file_ = molecule.ff.atomtypeFile
     
-    reader = csv.reader(open("./kappa/antechamber/%s" % (file_)), delimiter=" ")
+    reader = csv.reader(open("%s/antechamber/%s" % (package_dir,file_)), delimiter=" ")
     lines = []
     for line in reader:
         #populate lineList

--- a/kappa/forcefield.py
+++ b/kappa/forcefield.py
@@ -7,6 +7,8 @@ Created on Mon Mar 21 13:16:37 2016
 
 import numpy as np
 
+from . import package_dir
+
 #change in position for the finite difference equations
 ds = 1e-7
 dx = ds
@@ -36,6 +38,7 @@ class Amber(Forcefield):
                                "OW":21,"OH":22,"OS":23,"O":24,"O2":25,"S":26,"SH":27,"P":28,"H":29,"HW":30, 
                                "HO":31,"HS":32,"HA":33,"HC":34,"H1":35,"H2":36,"H3":37,"HP":38,"H4":39,"HS":40,
                                "DU":1}
+        self.atomtypeFile = "AMBER_kerr_edit.txt"
         
     def _configure_parameters(self, molecule):
         """Store parameters in bonds, angles, dihedrals, etc. along with non-bonded iteractions."""
@@ -45,7 +48,7 @@ class Amber(Forcefield):
         bondList = molecule.bondList
         angleList = molecule.angleList
         dihedralList = molecule.dihedralList
-        fileName = "./kappa/param/"+self.name
+        fileName = "%s/param/%s" % (package_dir, self.name)
         refArr = np.load(fileName+"/refArr.npy")
         r0Arr, epArr = np.load(fileName+"/vdwR.npy"), np.load(fileName+"/vdwE.npy")
         kbArr, l0Arr = np.load(fileName+"/kb.npy"), np.load(fileName+"/rb0.npy")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# python packages that are kappa dependencies
+numpy
+matplotlib


### PR DESCRIPTION
Created `requirements.txt`
Changed relative paths to absolute paths in regards to opening files such as `AMBER.txt` and the forcefield parameters stored in the `.npy` files (at least just for Amber, the only forcefield meaningfully implemented at this point.)

fixes #14 
